### PR TITLE
Add new dashboard widget with correct field mappings for stormapi internal threats, make search results collapsible, ignore .pydevproject hidden files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ build
 target
 dist
 lib
+.pydevproject

--- a/threatelligence-dashboards/app/dashboards/default.json
+++ b/threatelligence-dashboards/app/dashboards/default.json
@@ -176,10 +176,68 @@
       "notice": false
     },
     {
+      "title": "Internal Threats Search Results",
+      "height": "550px",
+      "editable": true,
+      "collapse": true,
+      "collapsable": true,
+      "panels": [
+        {
+          "error": false,
+          "span": 12,
+          "editable": true,
+          "type": "table",
+          "loadingEditor": false,
+          "size": 100,
+          "pages": 5,
+          "offset": 0,
+          "sort": [
+            "_score",
+            "desc"
+          ],
+          "overflow": "min-height",
+          "fields": [
+            "Patch",
+            "Severity",
+            "Name",
+            "DeviceType",
+            "InstalledApplictions",
+            "ApplicationVersion",
+            "Description",
+            "OperatingSystem",
+            "OperatingSystemVersion",
+            "Groups"
+          ],
+          "highlight": [],
+          "sortable": true,
+          "header": true,
+          "paging": true,
+          "field_list": false,
+          "all_fields": false,
+          "trimFactor": 300,
+          "localTime": false,
+          "timeField": "@timestamp",
+          "spyable": true,
+          "queries": {
+            "mode": "all",
+            "ids": [
+              0
+            ]
+          },
+          "style": {
+            "font-size": "9pt"
+          },
+          "normTimes": true,
+          "title": "Internal Threats Search Results"
+        }
+      ],
+      "notice": false
+    },
+    {
       "title": "Search Results",
       "height": "550px",
       "editable": true,
-      "collapse": false,
+      "collapse": true,
       "collapsable": true,
       "panels": [
         {
@@ -229,7 +287,7 @@
         }
       ],
       "notice": false
-    }
+    },
   ],
   "editable": true,
   "failover": false,


### PR DESCRIPTION
This pull request (PR) enables us to view stormapi results within the search results. It also makes the search results collapsible by default so we can fit more on the page. 
